### PR TITLE
Fix a stacked borrows violation in MIRI

### DIFF
--- a/src/linear_group/linear_group_by_key.rs
+++ b/src/linear_group/linear_group_by_key.rs
@@ -182,9 +182,11 @@ pub struct LinearGroupByKeyMut<'a, T: 'a, F> {
 
 impl<'a, T, F> LinearGroupByKeyMut<'a, T, F> {
     pub fn new(slice: &'a mut [T], func: F) -> Self {
+        let ptr = slice.as_mut_ptr();
+        let end = unsafe { ptr.add(slice.len()) };
         LinearGroupByKeyMut {
-            ptr: slice.as_mut_ptr(),
-            end: unsafe { slice.as_mut_ptr().add(slice.len()) },
+            ptr,
+            end,
             func,
             _phantom: marker::PhantomData,
         }

--- a/src/linear_group/mod.rs
+++ b/src/linear_group/mod.rs
@@ -227,6 +227,19 @@ mod tests {
         assert_eq!(iter.next_back(), Some(&[1, 2, 3, 4, 5][..]));
         assert_eq!(iter.next_back(), None);
     }
+
+    #[test]
+    fn group_by_key_mut() {
+        let slice = &mut [1, 2, 4, 5, 7, 8, 8];
+
+        let mut iter = LinearGroupByKeyMut::new(slice, |i: &i32| *i % 2);
+
+        assert_eq!(iter.next(), Some(&mut [1][..]));
+        assert_eq!(iter.next(), Some(&mut [2, 4][..]));
+        assert_eq!(iter.next(), Some(&mut [5, 7][..]));
+        assert_eq!(iter.next(), Some(&mut [8, 8][..]));
+        assert_eq!(iter.next(), None);
+    }
 }
 
 #[cfg(all(feature = "nightly", test))]


### PR DESCRIPTION
👋 Hi! Over at the [Wasmtime project](https://crates.io/crates/wasmtime) we're depending on this crate as part of the register allocation of Cranelift, and recent efforts to run some bits of Wasmtime in CI turned up this issue. I realize though that this crate has aged a bit and it's been awhile since it's been active, so no worries if times have changed! Otherwise though wanted to put this out there in case you are interested.

---

This commit fixes an error which comes about when running `cargo +nightly miri test` on a crate that depends on this library. MIRI implements experimental and upcoming versions of aliasing models for Rust to help assist with their refinement and clarification over time. The "error" here isn't really a deal-breaker per se as it's a pretty minor code change which I think is largely "just" appeasing MIRI. Despite this though I figured I'd try to get this upstream as it'd help us as we depend on this crate and are looking to run MIRI on our own code soon.

The issue at hand here is pretty subtle, but I believe the idea is that by calling `slice.as_mut_ptr()` a second time it invalidates the first pointer returned. Instead the fix is to base an end pointer on the starting pointer so both have the same provenance and are derived from the same original pointer.